### PR TITLE
Fix Webpacker manifest error in production

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -3,6 +3,7 @@
 set -o errexit
 
 bundle install
+yarn install --frozen-lockfile
 bundle exec rake assets:precompile
 bundle exec rake assets:clean
 bundle exec rake db:migrate


### PR DESCRIPTION
## Summary
- install yarn packages before assets:precompile

## Testing
- `bundle exec rails test` *(fails: rbenv: version `3.4.2` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6843686e459c83229a849582a151cb17