### PR TITLE
Fix missing webpacker manifest in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -26,8 +26,8 @@ Rails.application.configure do
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
 
-  # Do not fall back to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  # Allow Rails to compile missing assets in production.
+  config.assets.compile = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -82,8 +82,8 @@ test:
 production:
   <<: *default
 
-  # Production depends on precompilation of packs prior to booting for performance.
-  compile: false
+  # Compile assets on the fly in production to avoid missing pack errors.
+  compile: true
 
   # Extract and emit a css file
   extract_css: true


### PR DESCRIPTION
## Summary
- allow Rails to compile missing assets in production
- enable webpacker to compile packs on production

## Testing
- `bundle exec rspec` *(fails: rbenv version `3.4.2` is not installed)*
- `bin/rails test` *(fails: rbenv version `3.4.2` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68436937b8e48322b98f5efc95b9175b