### PR TITLE
Fix missing webpacker manifest in production

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,7 @@ GEM
       railties (>= 5.0.0)
     ffi (1.17.1)
     ffi (1.17.1-x86_64-darwin)
+    ffi (1.17.1-x86_64-linux)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.7)
@@ -169,6 +170,8 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     nokogiri (1.18.6-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.6-x86_64-linux)
       racc (~> 1.4)
     parallel (1.26.3)
     parser (3.3.7.3)
@@ -301,6 +304,8 @@ GEM
       railties (>= 7.0.0)
     tailwindcss-rails (2.7.9-x86_64-darwin)
       railties (>= 7.0.0)
+    tailwindcss-rails (2.7.9-x86_64-linux)
+      railties (>= 7.0.0)
     thor (1.3.2)
     tilt (2.6.0)
     timeout (0.4.3)
@@ -330,6 +335,7 @@ GEM
 PLATFORMS
   ruby
   x86_64-darwin-24
+  x86_64-linux
 
 DEPENDENCIES
   awesome_print (~> 1.9)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -26,8 +26,8 @@ Rails.application.configure do
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
 
-  # Do not fall back to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  # Allow Rails to compile missing assets in production.
+  config.assets.compile = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -82,8 +82,8 @@ test:
 production:
   <<: *default
 
-  # Production depends on precompilation of packs prior to booting for performance.
-  compile: false
+  # Compile assets on the fly in production to avoid missing pack errors.
+  compile: true
 
   # Extract and emit a css file
   extract_css: true


### PR DESCRIPTION
## Summary
- allow Rails to compile missing assets in production
- enable webpacker to compile packs on production
- add linux platform gems to fix tailwind build on render.com

## Testing
- `bundle exec rspec` *(fails: rbenv version `3.4.2` is not installed)*
- `bin/rails test` *(fails: rbenv version `3.4.2` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68436937b8e48322b98f5efc95b9175b